### PR TITLE
Edited script tags so ref to table tag is in html file instead of javascript files

### DIFF
--- a/addCol.js
+++ b/addCol.js
@@ -18,7 +18,7 @@
 // }
 
 // Implementation where addRow works:
-const table = document.getElementById("grid"); //get ref to table id grid
+//const table = document.getElementById("grid"); //get ref to table id grid // no longer needed as ref is in html file
 
 document.getElementById("addColumn").addEventListener("click", addColumn); //get the addcolumn element and add an event listener to it
 function addColumn() //func header

--- a/addRow.js
+++ b/addRow.js
@@ -1,5 +1,5 @@
 //add row
-const table = document.getElementById("grid"); //get ref to table id grid
+// const table = document.getElementById("grid"); //get ref to table id grid // no longer needed as ref is in html file
 document.getElementById("addRow").addEventListener("click", addRow); // added an event handler that gets tje elemnt from the id "add row" Then it will execute the function 
 function addRow() { // Declared the fucntion 
     const newRow = table.insertRow(); // adds a mew row to the table

--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
     </div>
     
     <table id="grid"></table>
+    <!-- get ref to table id grid -->
+    <script>
+        const table = document.getElementById("grid"); 
+    </script>
     
     <script src="addRow.js"></script> <!-- rahat -->
     <script src="addCol.js"></script> <!-- kazi -->


### PR DESCRIPTION
Me & Rahat ran into an issue regarding the table tag and the fix was to obtain the reference to the table (id grid) in the HTML file and comment out the reference in the individual javascript files. So moving onwards, there's no need for each javascript file in each method branch to have:
`const table = document.getElementById("grid");`
It would be redundant / cause unexpected errors. It's already in the HTML file so branches emerging from main should have the updated code already. 