### PR TITLE
Expand endless works

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,11 @@
             <option value="blue">Blue</option>
         </select>
     </div>
+
+    <div class="table-container">
+        <table id="grid"></table> <!-- get ref to table id grid -->
+    </div>
     
-    <table id="grid"></table>
-    <!-- get ref to table id grid -->
     <script>
         const table = document.getElementById("grid"); 
     </script>

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
         <button id="addColumn">Add Col</button>
         <button id="removeRow">Remove Row</button>
         <button id="removeColumn">Remove Col</button>
-        <button id="colorAll">Fill All Uncolored</button>
-        <button id="colorUncolored">Fill all</button>
+        <button id="colorAll">Fill All</button>
+        <button id="colorUncolored">Fill All Uncolored</button>
         <button id="removeColors">Clear</button>
         <select id="colorPicker">
             <option value="select">SELECT</option>

--- a/style.css
+++ b/style.css
@@ -15,6 +15,8 @@ table {
     margin-top: 10px;
     box-shadow: 0px 2px 8px rgba(0,0,0,0.5);
     margin: 0 auto;
+    max-width: 100%; /* maximum width, adds columns inside the grid */
+    max-height: 10%; /* maximum height, doesn't work for some reason? */
 }
 
 td {

--- a/style.css
+++ b/style.css
@@ -15,8 +15,6 @@ table {
     margin-top: 10px;
     box-shadow: 0px 2px 8px rgba(0,0,0,0.5);
     margin: 0 auto;
-    max-width: 100%; /* maximum width, adds columns inside the grid */
-    max-height: 10%; /* maximum height, doesn't work for some reason? */
 }
 
 td {
@@ -36,5 +34,12 @@ button {
 }
 
 body {
-    background-color: #E3E3E8; /* Gray background color */
+    background-color: #E3E3E8; /* background color */
+}
+
+.table-container {
+    width: 1900px; /* desired width - 57 columns but user can still add more columns, except it just makes columns in already defined grid */
+    height: 870px; /* desired height - 21 rows but user can still add more rows, except it it just adds vertical scroll bars instead of expanding off screen*/
+    overflow: auto;
+    margin: 0 auto;
 }


### PR DESCRIPTION
+ Grid doesn't expand endlessly off of the screen, either horizontally or vertically:

> + added width: 1900px to CSS so the desired width is 57 columns but the user can still add more columns, except it just makes columns in an already defined grid 
> + added height: 870px to CSS so the desired height - 21 rows but the user can still add more rows, except it it just adds vertical scroll bars instead of expanding off screen

+ This feature probably depends on what screen your using so maybe making it dynamic is an edge case but this should suffice for the extra credit along with the color wheel.